### PR TITLE
Only aggregate by latest failure

### DIFF
--- a/lib/hydra/build.rb
+++ b/lib/hydra/build.rb
@@ -18,6 +18,7 @@ module Hydra::Build
       .xpath("//*[contains(text(),'Failed build steps')]").first
       .next_element
       .css("tbody > tr")
+      .slice(0, 1)
       .map do |step|
         columns = step.css("td")
         what = columns[FAILED_BUILD_STEPS_COLUMNS[:what]].css("tt").first.text.split(",")


### PR DESCRIPTION
Previously the earliest would be shown, which could have been transient
and not relevant anymore.

Instead, show the first one, which is also the most recent one.

I'm a ruby noob, so please double-check me. Especially trimming it down to a list with a single item and then doing a map seems silly.